### PR TITLE
[PR] Instrument all malloc callsites

### DIFF
--- a/llvm-plugin/src/CVEAssert/bounds_check.cpp
+++ b/llvm-plugin/src/CVEAssert/bounds_check.cpp
@@ -308,20 +308,22 @@ void instrumentMalloc(Function *F) {
     resolveMallocFnTy
   );
 
-  for (auto &BB : *F) {
-    for (auto &inst: BB) {
-      if (auto *call = dyn_cast<CallInst>(&inst)) {
-        Function *calledFn = call->getCalledFunction();
+  for (auto &F : *M) {
+    for (auto &BB : F) {
+      for (auto &inst: BB) {
+        if (auto *call = dyn_cast<CallInst>(&inst)) {
+          Function *calledFn = call->getCalledFunction();
 
-        if (!calledFn) { continue; }
+          if (!calledFn) { continue; }
 
-        StringRef fnName = calledFn->getName();
+          StringRef fnName = calledFn->getName();
         
-        if (fnName == "malloc") { mallocList.push_back(call); }
+          if (fnName == "malloc") { mallocList.push_back(call); }
+        }
       }
     }
   }
-
+  
   for (auto Inst : mallocList) {
     builder.SetInsertPoint(Inst);
     Value *arg = Inst->getArgOperand(0);


### PR DESCRIPTION
This PR contains a modification to the bounds_check.cpp source file. Specifically, the goal of this PR is to instrument all malloc callsites in a program not just the callsites found within the affected function. The thought is that there can be edge cases where a program allocation and dereference operations occur within different functions still triggering a vulnerability. To resolve this, we instrument all malloc call sites to ensure that we capture all allocations across the program.  