### PR TITLE
Debug image histogram

### DIFF
--- a/llvm-plugin/src/CVEAssert/bounds_check.cpp
+++ b/llvm-plugin/src/CVEAssert/bounds_check.cpp
@@ -34,13 +34,13 @@ static FunctionCallee getResolveBaseAndLimit(Module *M) {
     false
   );
 
-  // MemoryEffects ME = MemoryEffects::readOnly()
-  //                   .getWithoutLoc(IRMemLocation::ArgMem);
+  MemoryEffects ME = MemoryEffects::readOnly()
+                    .getWithoutLoc(IRMemLocation::ArgMem);
 
   AttrBuilder FnAttrs(Ctx);
-  // FnAttrs.addAttribute(Attribute::getWithMemoryEffects(Ctx, ME));
-  // FnAttrs.addAttribute(Attribute::WillReturn);
-  // FnAttrs.addAttribute(Attribute::Speculatable);
+  FnAttrs.addAttribute(Attribute::getWithMemoryEffects(Ctx, ME));
+  FnAttrs.addAttribute(Attribute::WillReturn);
+  FnAttrs.addAttribute(Attribute::Speculatable);
 
   AttributeList attrs = AttributeList::get(Ctx, AttributeList::FunctionIndex, FnAttrs);
 


### PR DESCRIPTION
I am leaving this here as a note to self. Image-histogram breaks because of the API call to `PointerMayBeCaptured`. We can come back to figure out why it does not work.

This does not need to be merged.