### PR TITLE
[PR] Updating __cve_gep function name

### DIFF
--- a/resolve-cveassert/libresolve/src/remediate.rs
+++ b/resolve-cveassert/libresolve/src/remediate.rs
@@ -59,7 +59,6 @@ pub extern "C" fn __resolve_malloc(size: usize) -> *mut c_void {
         ptr as Vaddr
     );
 
-    // Return the pointer
     ptr
 }
 
@@ -80,7 +79,6 @@ pub extern "C" fn __resolve_free(ptr: *mut c_void) -> () {
 
     let ptr_size = {
         let mut obj_list = ALIVE_OBJ_LIST.lock();
-        // Lookup shadow object
         let sobj_opt = obj_list.search_intersection(ptr as Vaddr);
         let size = sobj_opt.map(|o| o.size());
         // remove shadow obj from live list

--- a/resolve-cveassert/src/bounds_check.cpp
+++ b/resolve-cveassert/src/bounds_check.cpp
@@ -108,7 +108,7 @@ static Function *getOrCreateAccessOk(Module *M) {
 
 static Function *getOrCreateBoundsCheckLoadSanitizer(
     Function *F, Type *ty, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_bound_ld_" + getLLVMType(ty);
+  std::string handlerName = "__cve_bound_ld_" + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];
@@ -170,7 +170,7 @@ static Function *getOrCreateBoundsCheckLoadSanitizer(
 
 static Function *getOrCreateBoundsCheckStoreSanitizer(
     Function *F, Type *ty, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_bound_st_" + getLLVMType(ty);
+  std::string handlerName = "__cve_bound_st_" + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];
@@ -236,7 +236,7 @@ static Function *getOrCreateBoundsCheckStoreSanitizer(
 
 static Function *getOrCreateBoundsCheckMemcpySanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_memcpy";
+  std::string handlerName = "__cve_memcpy";
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];
@@ -307,7 +307,7 @@ static Function *getOrCreateBoundsCheckMemcpySanitizer(
 
 static Function *getOrCreateBoundsCheckMemmoveSanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_memmove";
+  std::string handlerName = "__cve_memmove";
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];
@@ -379,7 +379,7 @@ static Function *getOrCreateBoundsCheckMemmoveSanitizer(
 
 static Function *getOrCreateBoundsCheckMemsetSanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_memset";
+  std::string handlerName = "__cve_memset";
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];

--- a/resolve-cveassert/src/bounds_check.cpp
+++ b/resolve-cveassert/src/bounds_check.cpp
@@ -448,7 +448,7 @@ static Function *getOrCreateBoundsCheckMemsetSanitizer(
 }
 
 static Function *getOrCreateResolveGep(Function *F) {
-  std::string handlerName = "__cve_san_gep";
+  std::string handlerName = "__cve_gep";
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];

--- a/resolve-cveassert/src/null_ptr.cpp
+++ b/resolve-cveassert/src/null_ptr.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 static Function *
 getOrCreateNullPtrLoadSanitizer(Function *F, Type *ty,
                                 Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_null_ptr_ld_" + getLLVMType(ty);
+  std::string handlerName = "__cve_null_check_ld_" + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];
@@ -93,7 +93,7 @@ getOrCreateNullPtrLoadSanitizer(Function *F, Type *ty,
 
 static Function *getOrCreateNullPtrStoreSanitizer(
     Function *F, Type *ty, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_san_null_ptr_st_" + getLLVMType(ty);
+  std::string handlerName = "__cve_null_check_st_" + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];

--- a/resolve-cveassert/tests/lit/buffer_overflow.c
+++ b/resolve-cveassert/tests/lit/buffer_overflow.c
@@ -7,7 +7,7 @@
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/buffer_overflow.json %clang -S -emit-llvm \
 // RUN: -fpass-plugin=%plugin \
 // RUN: %s -o - | %FileCheck %s 
-// CHECK: call ptr @__cve_san_memcpy
+// CHECK: call ptr @__cve_memcpy
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/buffer_overflow.json %clang -O0 -g -fpass-plugin=%plugin \ 
 // RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
 // RUN: %t.exe input.bin; test $? -eq 3

--- a/resolve-cveassert/tests/lit/memcpy_oob.c
+++ b/resolve-cveassert/tests/lit/memcpy_oob.c
@@ -7,7 +7,7 @@
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/memcpy_oob.json %clang -S -emit-llvm \
 // RUN: -fpass-plugin=%plugin \
 // RUN: %s -o - | %FileCheck %s 
-// CHECK: call ptr @__cve_san_memcpy 
+// CHECK: call ptr @__cve_memcpy 
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/memcpy_oob.json %clang -O0 -g -fpass-plugin=%plugin \ 
 // RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
 // RUN: %t.exe; test $? -eq 3

--- a/resolve-cveassert/tests/lit/memset_oob.c
+++ b/resolve-cveassert/tests/lit/memset_oob.c
@@ -7,7 +7,7 @@
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/memset_oob.json %clang -S -emit-llvm \
 // RUN: -fpass-plugin=%plugin \
 // RUN: %s -o - | %FileCheck %s 
-// CHECK: call ptr @__cve_san_memset 
+// CHECK: call ptr @__cve_memset 
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/memset_oob.json %clang -O0 -g -fpass-plugin=%plugin \ 
 // RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
 // RUN: %t.exe; test $? -eq 3

--- a/resolve-cveassert/tests/lit/oob_no_remed.c
+++ b/resolve-cveassert/tests/lit/oob_no_remed.c
@@ -6,7 +6,7 @@
 // RUN: %clang -S -emit-llvm \
 // RUN: %s -o - | %FileCheck %s 
 // CHECK-LABEL: dso_local i32 @main
-// CHECK-NOT: call ptr @__cve_san_memcpy
+// CHECK-NOT: call ptr @__cve_memcpy
 
 #include <stdlib.h>
 int loop(int *array) {

--- a/resolve-cveassert/tests/lit/safe_memset.c
+++ b/resolve-cveassert/tests/lit/safe_memset.c
@@ -7,7 +7,7 @@
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/safe_memset.json %clang -S -emit-llvm \
 // RUN: -fpass-plugin=%plugin \
 // RUN: %s -o - | %FileCheck %s 
-// CHECK: call ptr @__cve_san_memset
+// CHECK: call ptr @__cve_memset
 // RUN: RESOLVE_LABEL_CVE=vulnerabilities/memset_oob.json %clang -O0 -g -fpass-plugin=%plugin \ 
 // RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
 // RUN: %t.exe; test $? -eq 0


### PR DESCRIPTION
Updating `__cve_san_gep` to `__cve_gep` to reflect that the `gep` instruction is being instrumented not sanitized.