### PR TITLE
[PR] Adding metadata to sanitizer bitmaps

### DIFF
--- a/resolve-cveassert/src/CVEAssert.cpp
+++ b/resolve-cveassert/src/CVEAssert.cpp
@@ -61,7 +61,6 @@ GlobalVariable *initSanitizerMap(Function &F) {
     std::vector<Constant *> elems(7, ConstantInt::get(i1_ty, 1));
     gSanitizerMap->setInitializer(ConstantArray::get(arr_ty, elems));
   }
-
   return gSanitizerMap;
 }
 

--- a/resolve-cveassert/src/CVEAssert.cpp
+++ b/resolve-cveassert/src/CVEAssert.cpp
@@ -55,6 +55,7 @@ GlobalVariable *initSanitizerMap(Function &F) {
 
   gSanitizerMap->setLinkage(GlobalValue::LinkOnceAnyLinkage);
   gSanitizerMap->setConstant(false);
+  gSanitizerMap->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
 
   if (!gSanitizerMap->hasInitializer()) {
     std::vector<Constant *> elems(7, ConstantInt::get(i1_ty, 1));


### PR DESCRIPTION
This PR adds metadata to sanitizer bitmaps. I plan to add support to track global variables in libresolve and an easy way to filter out global variables created by the compiler is to attach metadata to them.