### PR TITLE
[PR] Pin glaze dependency

### DIFF
--- a/resolve-facts/CMakeLists.txt
+++ b/resolve-facts/CMakeLists.txt
@@ -25,7 +25,7 @@ FetchContent_Declare(
   glaze
   GIT_REPOSITORY https://github.com/stephenberry/glaze.git
   GIT_TAG 94222ecb0de39c5e6c83e708f0825ecb6aeae11f
-  GIT_SHALLOW TRUE
+  GIT_SHALLOW FALSE
 )
 
 set(glaze_INSTALL ON CACHE BOOL "Generate installation rules for glaze" FORCE)


### PR DESCRIPTION
Fixing glaze dependency issue. It looks like when the `GIT_SHALLOW` argument is set to true git cannot fetch the commit hash that we are pinning hopefully this fixes the issue. 