### PR TITLE
Isolate klee build with seperate make targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Install deps
         run: make install-deps
       - name: Build
-        run: make build
+        run: make build-klee
       - name: Install
-        run: make install
+        run: make install-klee
       - name: Test
-        run: make test
+        run: make test-klee
       - name: Check
-        run: make check
+        run: make check-klee
       - name: Build Examples
         run: ./examples/openssl.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # no build files
 **/build/*
+**/build-klee/*
 __pycache__
 CMakeFiles
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,11 @@ set(CMAKE_CXX_STANDARD 20 STRING "")
 add_subdirectory(resolve-cc)
 add_subdirectory(resolve-cveassert)
 add_subdirectory(resolve-facts)
-include(${CMAKE_SOURCE_DIR}/cmake/InstallKlee.cmake)
+
+option(RESOLVE_BUILD_KLEE "Build bundled KLEE support" OFF)
+if(RESOLVE_BUILD_KLEE)
+    include(${CMAKE_SOURCE_DIR}/cmake/InstallKlee.cmake)
+endif()
 add_subdirectory(resolve-cli)
 
 install(EXPORT resolve_targets 

--- a/Makefile
+++ b/Makefile
@@ -4,36 +4,55 @@
 SHELL := /bin/bash
 all: build
 
-.PHONY: build check test install clean
+BUILD_DIR ?= build
+RESOLVE_BUILD_KLEE ?= OFF
+CMAKE_ARGS := -GNinja -DRESOLVE_BUILD_KLEE=$(RESOLVE_BUILD_KLEE)
+
+.PHONY: build build-klee build-release build-release-klee check check-klee test test-klee install install-klee install-local clean
 configure: 
-	cmake -Bbuild -GNinja
+	cmake -B$(BUILD_DIR) $(CMAKE_ARGS)
 
 build: configure-default
-	cmake --build build
+	cmake --build $(BUILD_DIR)
+
+build-klee:
+	$(MAKE) build BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 configure-default: 
-	cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=
+	cmake -B$(BUILD_DIR) $(CMAKE_ARGS) -DCMAKE_BUILD_TYPE=
 
 build-release: configure-release
-	cmake --build build
+	cmake --build $(BUILD_DIR)
+
+build-release-klee:
+	$(MAKE) build-release BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 configure-release: 
-	cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
+	cmake -B$(BUILD_DIR) $(CMAKE_ARGS) -DCMAKE_BUILD_TYPE=Release
 
 check: configure
-	cmake --build build --target check
+	cmake --build $(BUILD_DIR) --target check
+
+check-klee:
+	$(MAKE) check BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 test: configure
-	cmake --build build --target test-CVEAssert test-libresolve
+	cmake --build $(BUILD_DIR) --target test-CVEAssert test-libresolve
+
+test-klee:
+	$(MAKE) test BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 install: configure
-	cmake --install build
+	cmake --install $(BUILD_DIR)
+
+install-klee:
+	$(MAKE) install BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 install-local: configure
-	cmake --install build --prefix install
+	cmake --install $(BUILD_DIR) --prefix install
 
 clean:
-	rm -rf build/
+	rm -rf build/ build-klee/
 
 .PHONY: install-deps
 install-deps:


### PR DESCRIPTION
Mostly done with codex, duplicates each of the resolve targets with KLEE builds defaulting off, opted into by using the `-klee` suffix or by settings a cmake var.