### PR TITLE
fix: use generic var name for build dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,52 +4,56 @@
 SHELL := /bin/bash
 all: build
 
-BUILD_DIR ?= build
+ifeq ($(origin BUILD_DIR),command line)
+RESOLVE_CMAKE_BUILD_DIR ?= $(BUILD_DIR)
+else
+RESOLVE_CMAKE_BUILD_DIR ?= build
+endif
 RESOLVE_BUILD_KLEE ?= OFF
 CMAKE_ARGS := -GNinja -DRESOLVE_BUILD_KLEE=$(RESOLVE_BUILD_KLEE)
 
 .PHONY: build build-klee build-release build-release-klee check check-klee test test-klee install install-klee install-local clean
 configure: 
-	cmake -B$(BUILD_DIR) $(CMAKE_ARGS)
+	cmake -B$(RESOLVE_CMAKE_BUILD_DIR) $(CMAKE_ARGS)
 
 build: configure-default
-	cmake --build $(BUILD_DIR)
+	cmake --build $(RESOLVE_CMAKE_BUILD_DIR)
 
 build-klee:
-	$(MAKE) build BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
+	$(MAKE) build RESOLVE_CMAKE_BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 configure-default: 
-	cmake -B$(BUILD_DIR) $(CMAKE_ARGS) -DCMAKE_BUILD_TYPE=
+	cmake -B$(RESOLVE_CMAKE_BUILD_DIR) $(CMAKE_ARGS) -DCMAKE_BUILD_TYPE=
 
 build-release: configure-release
-	cmake --build $(BUILD_DIR)
+	cmake --build $(RESOLVE_CMAKE_BUILD_DIR)
 
 build-release-klee:
-	$(MAKE) build-release BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
+	$(MAKE) build-release RESOLVE_CMAKE_BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 configure-release: 
-	cmake -B$(BUILD_DIR) $(CMAKE_ARGS) -DCMAKE_BUILD_TYPE=Release
+	cmake -B$(RESOLVE_CMAKE_BUILD_DIR) $(CMAKE_ARGS) -DCMAKE_BUILD_TYPE=Release
 
 check: configure
-	cmake --build $(BUILD_DIR) --target check
+	cmake --build $(RESOLVE_CMAKE_BUILD_DIR) --target check
 
 check-klee:
-	$(MAKE) check BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
+	$(MAKE) check RESOLVE_CMAKE_BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 test: configure
-	cmake --build $(BUILD_DIR) --target test-CVEAssert test-libresolve
+	cmake --build $(RESOLVE_CMAKE_BUILD_DIR) --target test-CVEAssert test-libresolve
 
 test-klee:
-	$(MAKE) test BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
+	$(MAKE) test RESOLVE_CMAKE_BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 install: configure
-	cmake --install $(BUILD_DIR)
+	cmake --install $(RESOLVE_CMAKE_BUILD_DIR)
 
 install-klee:
-	$(MAKE) install BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
+	$(MAKE) install RESOLVE_CMAKE_BUILD_DIR=build-klee RESOLVE_BUILD_KLEE=ON
 
 install-local: configure
-	cmake --install $(BUILD_DIR) --prefix install
+	cmake --install $(RESOLVE_CMAKE_BUILD_DIR) --prefix install
 
 clean:
 	rm -rf build/ build-klee/


### PR DESCRIPTION
The naming of BUILD_DIR int he makefile collides with an environment variable in integrate