### PR TITLE
Fix image names in publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:git-${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:git-${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,7 @@ jobs:
           context: .
           push: true
           tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:git-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:git-${{ github.sha }}
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
the .repository variable appears to already prepend <owner>/ to the repo name, so doing it ourselves is redundant?