### PR TITLE
[PR] Replace hardcoded function names with macro substitution

### DIFF
--- a/resolve-cveassert/src/bounds_check.cpp
+++ b/resolve-cveassert/src/bounds_check.cpp
@@ -39,13 +39,13 @@ static FunctionCallee getOrCreateResolveGetBounds(Module *M) {
   AttributeList attrs =
       AttributeList::get(Ctx, AttributeList::FunctionIndex, FnAttrs);
 
-  return M->getOrInsertFunction("__resolve_get_bounds",
+  return M->getOrInsertFunction(RESOLVE_FN("get_bounds"),
                                 FunctionType::get(struct_ty, {ptr_ty}, false),
                                 attrs);
 }
 
 static Function *getOrCreateAccessOk(Module *M) {
-  std::string handlerName = "__cve_access_ok";
+  std::string handlerName = CVE_FN("access_ok");
   LLVMContext &Ctx = M->getContext();
 
   IRBuilder<> builder(Ctx);
@@ -110,7 +110,7 @@ static Function *getOrCreateAccessOk(Module *M) {
 
 static Function *getOrCreateBoundsCheckLoadSanitizer(
     Function *F, Type *ty, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_bound_ld_" + getLLVMType(ty);
+  std::string handlerName = CVE_FN("bound_ld_") + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -169,7 +169,7 @@ static Function *getOrCreateBoundsCheckLoadSanitizer(
 
 static Function *getOrCreateBoundsCheckStoreSanitizer(
     Function *F, Type *ty, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_bound_st_" + getLLVMType(ty);
+  std::string handlerName = CVE_FN("bound_st_") + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -232,7 +232,7 @@ static Function *getOrCreateBoundsCheckStoreSanitizer(
 
 static Function *getOrCreateBoundsCheckMemcpySanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_memcpy";
+  std::string handlerName = CVE_FN("memcpy");
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -300,7 +300,7 @@ static Function *getOrCreateBoundsCheckMemcpySanitizer(
 
 static Function *getOrCreateBoundsCheckMemmoveSanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_memmove";
+  std::string handlerName = CVE_FN("memmove");
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -369,7 +369,7 @@ static Function *getOrCreateBoundsCheckMemmoveSanitizer(
 
 static Function *getOrCreateBoundsCheckMemsetSanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_memset";
+  std::string handlerName = CVE_FN("memset");
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -436,7 +436,7 @@ static Function *getOrCreateBoundsCheckMemsetSanitizer(
 }
 
 static Function *getOrCreateResolveGep(Function *F) {
-  std::string handlerName = "__cve_gep";
+  std::string handlerName = CVE_FN("gep");
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 

--- a/resolve-cveassert/src/helpers.hpp
+++ b/resolve-cveassert/src/helpers.hpp
@@ -15,6 +15,11 @@
 
 #include <string>
 
+#define RESOLVE_PREFIX "__resolve_"
+#define CVE_PREFIX "__cve_"
+#define RESOLVE_FN(name) RESOLVE_PREFIX name
+#define CVE_FN(name) CVE_PREFIX name
+
 std::string getLLVMType(llvm::Type *ty);
 llvm::Function *getOrCreateResolveReportSanitizerTriggered(llvm::Module *M);
 llvm::Function *

--- a/resolve-cveassert/src/instrument.cpp
+++ b/resolve-cveassert/src/instrument.cpp
@@ -90,9 +90,10 @@ void instrumentAlloca(Function *F) {
   SmallVector<AllocaInst *, 16> shadowSlots;
 
   auto allocateFn = M->getOrInsertFunction(
-      "__resolve_alloca", FunctionType::get(void_ty, {ptr_ty, size_ty}, false));
+      RESOLVE_FN("alloca"),
+      FunctionType::get(void_ty, {ptr_ty, size_ty}, false));
   auto invalidateFn =
-      M->getOrInsertFunction("__resolve_invalidate_stack",
+      M->getOrInsertFunction(RESOLVE_FN("invalidate_stack"),
                              FunctionType::get(void_ty, {ptr_ty}, false));
 
   // 2 cases

--- a/resolve-cveassert/src/nonheap_free.cpp
+++ b/resolve-cveassert/src/nonheap_free.cpp
@@ -20,7 +20,7 @@ Function *getOrCreateIsHeap(Function *F) {
 
   FunctionType *cveIsHeapFnTy = FunctionType::get(i1_ty, {ptr_ty}, false);
   Function *cveIsHeapFn =
-      getOrCreateResolveHelper(M, "__cve_is_heap", cveIsHeapFnTy);
+      getOrCreateResolveHelper(M, CVE_FN("is_heap"), cveIsHeapFnTy);
 
   if (!cveIsHeapFn->empty()) {
     return cveIsHeapFn;
@@ -59,7 +59,6 @@ Function *getOrCreateIsHeap(Function *F) {
 
 Function *getOrCreateFreeOfNonHeapSanitizer(
     Function *F, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_nonheap_free";
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
   GlobalVariable *map = SanitizerMaps[F];
@@ -74,7 +73,7 @@ Function *getOrCreateFreeOfNonHeapSanitizer(
   FunctionType *cveFreeNonHeapFnTy =
       FunctionType::get(Type::getVoidTy(Ctx), {ptr_ty}, false);
   Function *cveFreeNonHeapFn =
-      getOrCreateResolveHelper(M, handlerName, cveFreeNonHeapFnTy);
+      getOrCreateResolveHelper(M, CVE_FN("nonheap_free"), cveFreeNonHeapFnTy);
   if (!cveFreeNonHeapFn->empty()) {
     return cveFreeNonHeapFn;
   }

--- a/resolve-cveassert/src/null_ptr.cpp
+++ b/resolve-cveassert/src/null_ptr.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 static Function *
 getOrCreateNullPtrLoadSanitizer(Function *F, Type *ty,
                                 Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_null_check_ld_" + getLLVMType(ty);
+  std::string handlerName = CVE_FN("null_check_ld_") + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -74,7 +74,7 @@ getOrCreateNullPtrLoadSanitizer(Function *F, Type *ty,
     break;
 
   default:
-    llvm_unreachable("Not a supported strategy");
+    llvm_unreachable("Not a supported strategy!");
   }
 
   builder.SetInsertPoint(NormalLoadBB);
@@ -88,7 +88,7 @@ getOrCreateNullPtrLoadSanitizer(Function *F, Type *ty,
 
 static Function *getOrCreateNullPtrStoreSanitizer(
     Function *F, Type *ty, Vulnerability::RemediationStrategies strategy) {
-  std::string handlerName = "__cve_null_check_st_" + getLLVMType(ty);
+  std::string handlerName = CVE_FN("null_check_st_") + getLLVMType(ty);
   Module *M = F->getParent();
   LLVMContext &Ctx = M->getContext();
 
@@ -147,7 +147,7 @@ static Function *getOrCreateNullPtrStoreSanitizer(
     break;
 
   default:
-    llvm_unreachable("Not a supported strategy");
+    llvm_unreachable("Not a supported strategy!");
   }
 
   // Return Block: returns pointer if non-null


### PR DESCRIPTION
This PR is a quality-of-life improvement for CVEAssert. I took inspiration from the [BorrowSanitizer](https://github.com/BorrowSanitizer/bsan/blob/f1dd3d1513e2486d33dedd152d090f5f3acc519a/bsan-pass/Retag.h) project and replaced all hard coded function names with a macro definition. 