### PR TITLE
Pre-packaged release builder and CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: resolve release
 on:
   push:
     tags:
-      - "v*[0-9]*"
+      - "v[0-9]*"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: resolve release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: make install-deps
+
+      - name: Build release package
+        run: make release
+
+      - name: Validate release package
+        run: |
+          set -euo pipefail
+
+          artifact="dist/resolve-linux-x86_64.tar.gz"
+
+          test -s "$artifact"
+          tar -tzf "$artifact" | grep -q '^opt/resolve/'
+          tar -tzf "$artifact" | grep -q '^usr/local/bin/resolve$'
+          tar -tzf "$artifact" | grep -q '^usr/local/bin/resolvecc$'
+
+      - name: Prepare release metadata
+        id: release-meta
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          if [[ "$tag" =~ (alpha|beta|rc|pre|dev|snapshot) ]]; then
+            echo "prerelease_flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease_flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+          cat > release-notes.md <<EOF
+          ## Install
+
+          ~~~bash
+          curl -fL https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/resolve-linux-x86_64.tar.gz \
+            -o /tmp/resolve-linux-x86_64.tar.gz && \
+          sudo tar -C / -xzf /tmp/resolve-linux-x86_64.tar.gz
+          ~~~
+          EOF
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE_FLAG: ${{ steps.release-meta.outputs.prerelease_flag }}
+        run: |
+          set -euo pipefail
+
+          release_notes="$(cat release-notes.md)"
+
+          gh release create "$GITHUB_REF_NAME" \
+            dist/resolve-linux-x86_64.tar.gz \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes "$release_notes" \
+            --generate-notes \
+            $PRERELEASE_FLAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: resolve release
 on:
   push:
     tags:
-      - "v*"
+      - "v*[0-9]*"
 
 permissions:
   contents: write
@@ -30,9 +30,10 @@ jobs:
           artifact="dist/resolve-linux-x86_64.tar.gz"
 
           test -s "$artifact"
-          tar -tzf "$artifact" | grep -q '^opt/resolve/'
-          tar -tzf "$artifact" | grep -q '^usr/local/bin/resolve$'
-          tar -tzf "$artifact" | grep -q '^usr/local/bin/resolvecc$'
+          tar -tzf "$artifact" > release-contents.txt
+          grep -q '^opt/resolve/' release-contents.txt
+          grep -q '^usr/local/bin/resolve$' release-contents.txt
+          grep -q '^usr/local/bin/resolvecc$' release-contents.txt
 
       - name: Prepare release metadata
         id: release-meta
@@ -50,8 +51,8 @@ jobs:
           ## Install
 
           ~~~bash
-          curl -fL https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/resolve-linux-x86_64.tar.gz \
-            -o /tmp/resolve-linux-x86_64.tar.gz && \
+          curl -fL https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/resolve-linux-x86_64.tar.gz \\
+            -o /tmp/resolve-linux-x86_64.tar.gz && \\
           sudo tar -C / -xzf /tmp/resolve-linux-x86_64.tar.gz
           ~~~
           EOF

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ CMakeCache.txt
 
 # local install folder
 install/
+build-release/
+dist/
 
 # ignore repos/outputs from tests
 llvm-plugin/tests/**/*.ll

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,13 @@ endif
 RESOLVE_BUILD_KLEE ?= OFF
 CMAKE_ARGS := -GNinja -DRESOLVE_BUILD_KLEE=$(RESOLVE_BUILD_KLEE)
 
-.PHONY: build build-with-klee build-release build-release-with-klee check check-with-klee test test-with-klee install install-with-klee install-local clean
+RELEASE_BUILD_DIR ?= build-release
+RELEASE_STAGE_DIR ?= dist/resolve-release-root
+RELEASE_TARBALL ?= dist/resolve-linux-x86_64.tar.gz
+RELEASE_INSTALL_PREFIX ?= /opt/resolve
+RELEASE_PYTHON_VERSION ?= 3.12
+
+.PHONY: build build-with-klee build-release build-release-with-klee check check-with-klee test test-with-klee install install-with-klee install-local release clean
 configure: 
 	cmake -B$(RESOLVE_CMAKE_BUILD_DIR) $(CMAKE_ARGS)
 
@@ -65,6 +71,11 @@ install-with-klee:
 
 install-local: configure
 	cmake --install $(RESOLVE_CMAKE_BUILD_DIR) --prefix install
+
+release:
+	cmake -B$(RELEASE_BUILD_DIR) -GNinja -DRESOLVE_BUILD_KLEE=OFF -DRESOLVE_BUNDLE_PYTHON=ON -DRESOLVE_PYTHON_VERSION=$(RELEASE_PYTHON_VERSION) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(RELEASE_INSTALL_PREFIX) -DCMAKE_INSTALL_RPATH='$$ORIGIN;$$ORIGIN/../lib'
+	cmake --build $(RELEASE_BUILD_DIR)
+	./scripts/package-release.sh $(RELEASE_BUILD_DIR) $(RELEASE_STAGE_DIR) $(RELEASE_TARBALL) $(RELEASE_INSTALL_PREFIX)
 
 clean:
 	rm -rf build/ build-with-klee/

--- a/resolve-cc/bin/resolvecc
+++ b/resolve-cc/bin/resolvecc
@@ -8,13 +8,29 @@ set -e
 # set -x # for debugging
 # RESOLVECC_DEBUG=true
 
-SCRIPT_DIR="${0%/*}"
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [ -L "$SCRIPT_PATH" ]; do
+    SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+    LINK_TARGET="$(readlink "$SCRIPT_PATH")"
+    case "$LINK_TARGET" in
+        /*) SCRIPT_PATH="$LINK_TARGET" ;;
+        *)  SCRIPT_PATH="$SCRIPT_DIR/$LINK_TARGET" ;;
+    esac
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 
 # Path for clang
 case "$0" in
-    *"cxx") REAL_CLANG=$(which clang++) ;;
-    *)      REAL_CLANG=$(which clang) ;;
+    *"cxx")
+        CLANG_COMMAND=clang++
+        CLANG_PACKAGE=clang
+        ;;
+    *)
+        CLANG_COMMAND=clang
+        CLANG_PACKAGE=clang
+        ;;
 esac
+REAL_CLANG=$(command -v "$CLANG_COMMAND" || true)
 
 RESOLVE_LIB_DIR=${RESOLVE_LIB_DIR:-"$SCRIPT_DIR"/../lib}
 
@@ -34,7 +50,7 @@ USE_RESOLVE_FACTS=true
 RESOLVE_LABEL_CVE=${RESOLVE_LABEL_CVE:-}
 
 # Variables stores the compilers name
-CLANG_COMPILER_NAME=${CLANG_COMPILER_NAME:-"$(basename "$REAL_CLANG")"}
+CLANG_COMPILER_NAME=${CLANG_COMPILER_NAME:-"${REAL_CLANG:-$CLANG_COMMAND}"}
 RESOLVE_COMPILER_NAME=${RESOLVE_COMPILER_NAME:-"$(basename "$0")"}
 
 # Variable tells resolvecc to load CVEAssert plugin
@@ -115,6 +131,13 @@ parse_args() {
 }
 
 configure_flags() {
+    if [[ -z "$REAL_CLANG" ]]; then
+        echo "[resolvecc]: ERROR: required compiler '$CLANG_COMMAND' was not found on PATH." >&2
+        echo "[resolvecc]: Install '$CLANG_PACKAGE' or add '$CLANG_COMMAND' to PATH." >&2
+        echo "[resolvecc]: On Ubuntu, try: sudo apt install clang-18" >&2
+        echo "[resolvecc]: If only clang-18/clang++-18 exists, create unversioned clang/clang++ symlinks or configure alternatives." >&2
+        exit 127
+    fi
 
     # Check if USE_CVEASSERT var is set to true
     if $USE_CVEASSERT; then

--- a/resolve-cc/bin/resolvecc
+++ b/resolve-cc/bin/resolvecc
@@ -22,15 +22,17 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 # Path for clang
 case "$0" in
     *"cxx")
-        CLANG_COMMAND=clang++
-        CLANG_PACKAGE=clang
+        CLANG_COMMAND=clang++-18
+        CLANG_FALLBACK_COMMAND=clang++
+        CLANG_PACKAGE=clang-18
         ;;
     *)
-        CLANG_COMMAND=clang
-        CLANG_PACKAGE=clang
+        CLANG_COMMAND=clang-18
+        CLANG_FALLBACK_COMMAND=clang
+        CLANG_PACKAGE=clang-18
         ;;
 esac
-REAL_CLANG=$(command -v "$CLANG_COMMAND" || true)
+REAL_CLANG=$(command -v "$CLANG_COMMAND" || command -v "$CLANG_FALLBACK_COMMAND" || true)
 
 RESOLVE_LIB_DIR=${RESOLVE_LIB_DIR:-"$SCRIPT_DIR"/../lib}
 
@@ -135,7 +137,15 @@ configure_flags() {
         echo "[resolvecc]: ERROR: required compiler '$CLANG_COMMAND' was not found on PATH." >&2
         echo "[resolvecc]: Install '$CLANG_PACKAGE' or add '$CLANG_COMMAND' to PATH." >&2
         echo "[resolvecc]: On Ubuntu, try: sudo apt install clang-18" >&2
-        echo "[resolvecc]: If only clang-18/clang++-18 exists, create unversioned clang/clang++ symlinks or configure alternatives." >&2
+        echo "[resolvecc]: If you use a non-Ubuntu LLVM install, make sure clang 18 is first on PATH." >&2
+        exit 127
+    fi
+
+    CLANG_VERSION_OUTPUT=$("$REAL_CLANG" --version 2>/dev/null | sed -n '1p' || true)
+    if [[ "$CLANG_VERSION_OUTPUT" != *"version 18."* ]]; then
+        echo "[resolvecc]: ERROR: RESOLVE plugins require clang 18, but '$REAL_CLANG' reported:" >&2
+        echo "[resolvecc]: $CLANG_VERSION_OUTPUT" >&2
+        echo "[resolvecc]: On Ubuntu, install clang-18 or put clang 18 first on PATH." >&2
         exit 127
     fi
 

--- a/resolve-cli/CMakeLists.txt
+++ b/resolve-cli/CMakeLists.txt
@@ -1,93 +1,68 @@
 # Copyright (c) 2025 Riverside Research.
 # LGPL-3; See LICENSE.txt in the repo root for details.
 
-# Make install directory a pyvenv if it does not already contain a python interpreter
+set(RESOLVE_PYTHON_VERSION "3.12" CACHE STRING "Python version used for the resolve CLI environment")
+option(RESOLVE_BUNDLE_PYTHON "Install a uv-managed Python into the resolve install prefix" OFF)
+
+# Make the install prefix a Python environment for the resolve CLI tools.
 install(CODE "
-    function(is_path_in_prefix INPUT_PATH RESULT_VAR)
-        # Normalize both paths to absolute, real paths
-        get_filename_component(_path_real \"\${INPUT_PATH}\" REALPATH)
-        get_filename_component(_prefix_real \"\${CMAKE_INSTALL_PREFIX}\" REALPATH)
+    set(_resolve_python_version \"${RESOLVE_PYTHON_VERSION}\")
+    set(_resolve_bundle_python \"${RESOLVE_BUNDLE_PYTHON}\")
 
-        # Check whether the input path begins with the prefix
-        string(FIND \"\${_path_real}\" \"\${_prefix_real}\" _pos)
-
-        if(_pos EQUAL 0)
-            set(\${RESULT_VAR} TRUE PARENT_SCOPE)
+    set(_install_prefix \"\${CMAKE_INSTALL_PREFIX}\")
+    if(DEFINED ENV{DESTDIR} AND NOT \"\$ENV{DESTDIR}\" STREQUAL \"\")
+        if(IS_ABSOLUTE \"\${_install_prefix}\")
+            set(_install_prefix \"\$ENV{DESTDIR}\${_install_prefix}\")
         else()
-            set(\${RESULT_VAR} FALSE PARENT_SCOPE)
+            set(_install_prefix \"\$ENV{DESTDIR}/\${_install_prefix}\")
         endif()
-    endfunction()
-
-    execute_process(
-        COMMAND uv python find --project \"${CMAKE_CURRENT_SOURCE_DIR}\" \"\${CMAKE_INSTALL_PREFIX}\"
-        RESULT_VARIABLE _uv_result
-        OUTPUT_VARIABLE _uv_python_path
-        ERROR_QUIET
-    )
-        
-    if(_uv_result EQUAL 0)
-        message(STATUS \"Python interpreter found in install prefix: \${_uv_python_path}\")
-    else()
-        message(STATUS \"No Python interpreter found in install prefix\")
-        message(STATUS \"Creating a python venv at install prefix...\")
-    
-        execute_process(
-            COMMAND uv python find --project \"${CMAKE_CURRENT_SOURCE_DIR}\"
-            RESULT_VARIABLE _uv_result
-            OUTPUT_VARIABLE _uv_python_path
-        )
-        
-        string(STRIP \"\${_uv_python_path}\" _uv_python_path)
-
-        message(STATUS \"Using python at \${_uv_python_path}\")
-    
-        # Link the main bin/python exe
-        file(CREATE_LINK
-            \"\${_uv_python_path}\"
-            \"\${CMAKE_INSTALL_PREFIX}/bin/python\"
-            SYMBOLIC
-        )
-
-        # Link bin/python3.x and bin/python3
-        execute_process(
-            COMMAND \"\${_uv_python_path}\" -I -c \"import sys; print('python{}.{}'.format(sys.version_info.major, sys.version_info.minor))\"
-            OUTPUT_VARIABLE _py_exe
-            COMMAND_ERROR_IS_FATAL ANY
-        )
-        string(STRIP \"\${_py_exe}\" _py_exe)
-        file(CREATE_LINK
-            \"\${_uv_python_path}\"
-            \"\${CMAKE_INSTALL_PREFIX}/bin/\${_py_exe}\"
-            SYMBOLIC
-        )
-        execute_process(
-            COMMAND \"\${_uv_python_path}\" -I -c \"import sys; print('python{}'.format(sys.version_info.major))\"
-            OUTPUT_VARIABLE _py_exe
-            COMMAND_ERROR_IS_FATAL ANY
-        )
-        string(STRIP \"\${_py_exe}\" _py_exe)
-        file(CREATE_LINK
-            \"\${_uv_python_path}\"
-            \"\${CMAKE_INSTALL_PREFIX}/bin/\${_py_exe}\"
-            SYMBOLIC
-        )
-
-        # Create pyvenv.cfg
-        message(STATUS \"Creating pyvenv.cfg\")
-        cmake_path(GET _uv_python_path PARENT_PATH _python_home)
-
-        file(WRITE
-            \"\${CMAKE_INSTALL_PREFIX}/pyvenv.cfg\" \"home = \${_python_home}\\n\"
-        )
-
     endif()
+
+    file(MAKE_DIRECTORY \"\${_install_prefix}/bin\")
+
+    if(_resolve_bundle_python)
+        set(_python_install_dir \"\${_install_prefix}/python\")
+        message(STATUS \"Installing uv-managed Python \${_resolve_python_version} into \${_python_install_dir}\")
+        execute_process(
+            COMMAND uv python install \"\${_resolve_python_version}\" --install-dir \"\${_python_install_dir}\" --no-bin
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+
+        file(GLOB _managed_python_candidates
+            \"\${_python_install_dir}/*/bin/python\${_resolve_python_version}\"
+            \"\${_python_install_dir}/*/bin/python3\"
+            \"\${_python_install_dir}/*/bin/python\"
+        )
+        list(LENGTH _managed_python_candidates _managed_python_count)
+        if(_managed_python_count EQUAL 0)
+            message(FATAL_ERROR \"uv did not install a Python interpreter under \${_python_install_dir}\")
+        endif()
+        list(GET _managed_python_candidates 0 _uv_python_path)
+    else()
+        set(_uv_python_path \"\${_resolve_python_version}\")
+    endif()
+
+    message(STATUS \"Creating resolve Python environment at \${_install_prefix}\")
+    execute_process(
+        COMMAND uv venv --allow-existing --relocatable --python \"\${_uv_python_path}\" \"\${_install_prefix}\"
+        COMMAND_ERROR_IS_FATAL ANY
+    )
 ")
 
 # Install as python package with uv
 install(CODE "
+    set(_install_prefix \"\${CMAKE_INSTALL_PREFIX}\")
+    if(DEFINED ENV{DESTDIR} AND NOT \"\$ENV{DESTDIR}\" STREQUAL \"\")
+        if(IS_ABSOLUTE \"\${_install_prefix}\")
+            set(_install_prefix \"\$ENV{DESTDIR}\${_install_prefix}\")
+        else()
+            set(_install_prefix \"\$ENV{DESTDIR}/\${_install_prefix}\")
+        endif()
+    endif()
+
     message(STATUS \"Installing resolve-triage python package with uv pip install...\")
     execute_process(
-        COMMAND uv pip install --compile-bytecode --python \"\${CMAKE_INSTALL_PREFIX}\" \"${CMAKE_CURRENT_SOURCE_DIR}\"
+        COMMAND uv pip install --compile-bytecode --python \"\${_install_prefix}\" \"${CMAKE_CURRENT_SOURCE_DIR}\"
         RESULT_VARIABLE _uv_result
     )
     if(NOT _uv_result EQUAL 0)

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Riverside Research.
+# LGPL-3; See LICENSE.txt in the repo root for details.
+
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <build-dir> <stage-dir> <tarball> <install-prefix>" >&2
+    exit 2
+fi
+
+BUILD_DIR_INPUT=$1
+STAGE_DIR_INPUT=$2
+TARBALL_INPUT=$3
+INSTALL_PREFIX=${4%/}
+
+if [[ "$INSTALL_PREFIX" != /* ]]; then
+    echo "error: install prefix must be absolute: $INSTALL_PREFIX" >&2
+    exit 2
+fi
+
+BUILD_DIR=$(cd "$BUILD_DIR_INPUT" && pwd)
+TARBALL_DIR=$(dirname "$TARBALL_INPUT")
+TARBALL_NAME=$(basename "$TARBALL_INPUT")
+
+cmake -E rm -rf "$STAGE_DIR_INPUT"
+cmake -E make_directory "$STAGE_DIR_INPUT"
+cmake -E make_directory "$TARBALL_DIR"
+
+STAGE_DIR=$(cd "$STAGE_DIR_INPUT" && pwd)
+TARBALL_DIR=$(cd "$TARBALL_DIR" && pwd)
+TARBALL="$TARBALL_DIR/$TARBALL_NAME"
+STAGED_PREFIX="${STAGE_DIR}${INSTALL_PREFIX}"
+
+DESTDIR="$STAGE_DIR" cmake --install "$BUILD_DIR"
+
+if [ ! -d "$STAGED_PREFIX" ]; then
+    echo "error: expected staged install at $STAGED_PREFIX" >&2
+    exit 1
+fi
+
+if [ ! -d "$STAGED_PREFIX/python" ]; then
+    echo "error: release package expected bundled Python under $STAGED_PREFIX/python" >&2
+    exit 1
+fi
+
+copy_runtime_library() {
+    local soname=$1
+    local candidate=
+
+    for dir in /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib64 /usr/lib; do
+        if [ -e "$dir/$soname" ]; then
+            candidate="$dir/$soname"
+            break
+        fi
+    done
+
+    if [ -z "$candidate" ]; then
+        echo "error: could not find runtime library $soname" >&2
+        exit 1
+    fi
+
+    local target
+    target=$(readlink -f "$candidate")
+    cp -f "$target" "$STAGED_PREFIX/lib/$(basename "$target")"
+
+    if [ "$(basename "$target")" != "$soname" ]; then
+        ln -sfn "$(basename "$target")" "$STAGED_PREFIX/lib/$soname"
+    fi
+}
+
+copy_runtime_library libstdc++.so.6
+copy_runtime_library libgcc_s.so.1
+
+MANAGED_PYTHON=$(
+    find "$STAGED_PREFIX/python" -path "*/bin/python3*" -type f | sort | head -n 1
+)
+
+if [ -z "$MANAGED_PYTHON" ]; then
+    echo "error: could not find bundled Python interpreter under $STAGED_PREFIX/python" >&2
+    exit 1
+fi
+
+MANAGED_PYTHON_REL=${MANAGED_PYTHON#"$STAGED_PREFIX"/}
+MANAGED_PYTHON_FINAL="$INSTALL_PREFIX/$MANAGED_PYTHON_REL"
+PYTHON_MINOR=$(basename "$MANAGED_PYTHON")
+
+ln -sfn "$MANAGED_PYTHON_FINAL" "$STAGED_PREFIX/bin/python"
+ln -sfn python "$STAGED_PREFIX/bin/python3"
+ln -sfn python "$STAGED_PREFIX/bin/$PYTHON_MINOR"
+
+if [ -f "$STAGED_PREFIX/pyvenv.cfg" ]; then
+    sed -i "s|$STAGED_PREFIX|$INSTALL_PREFIX|g" "$STAGED_PREFIX/pyvenv.cfg"
+fi
+
+for file in "$STAGED_PREFIX"/bin/*; do
+    [ -f "$file" ] || continue
+    magic=$(head -c 2 "$file" || true)
+    [ "$magic" = "#!" ] || continue
+    first_line=$(sed -n '1p' "$file" || true)
+    case "$first_line" in
+        "#!"*"python"*)
+            sed -i "1c#!$INSTALL_PREFIX/bin/python3" "$file"
+            chmod +x "$file"
+            ;;
+    esac
+done
+
+cmake -E make_directory "$STAGE_DIR/usr/local/bin"
+for cmd in "$STAGED_PREFIX"/bin/resolve* "$STAGED_PREFIX"/bin/reach "$STAGED_PREFIX"/bin/resolve_read_props; do
+    [ -e "$cmd" ] || continue
+    cmd_name=$(basename "$cmd")
+    ln -sfn "$INSTALL_PREFIX/bin/$cmd_name" "$STAGE_DIR/usr/local/bin/$cmd_name"
+done
+
+tar -C "$STAGE_DIR" -czf "$TARBALL" opt usr
+
+echo "Created $TARBALL"
+echo "Install with: sudo tar -C / -xzf $TARBALL"


### PR DESCRIPTION
`scripts/package-release.sh` creates a tarball that can be extracted to `/` to install `/opt/resolve` and `/usr/lib` packages such that the user has a resolve installation inserted into their machine. I (used codex to) make some changes to the way we build such a release that makes it bundle a python 3.12 install so users do not need uv or python. Still a WIP