### PR TITLE
Add Global Tracking to libresolve

### DIFF
--- a/resolve-cveassert/libresolve/src/remediate.rs
+++ b/resolve-cveassert/libresolve/src/remediate.rs
@@ -314,10 +314,7 @@ pub extern "C" fn __resolve_get_bounds_heap(ptr: *mut c_void) -> ShadowObjBounds
 #[unsafe(no_mangle)]
 pub extern "C" fn __resolve_get_bounds_global(ptr: *mut c_void) -> ShadowObjBounds {
     match lookup_global(ptr as Vaddr) {
-        Some(obj) => ShadowObjBounds {
-            base: obj.base as *mut c_void,
-            limit: obj.past_limit() as *mut c_void
-        },
+        Some(obj) => (&obj).into(),
         None => ShadowObjBounds::null()
     }
 }

--- a/resolve-cveassert/libresolve/src/remediate.rs
+++ b/resolve-cveassert/libresolve/src/remediate.rs
@@ -4,7 +4,7 @@ use libc::{
     c_char, c_void, calloc, free, malloc, realloc, strdup, strlen, strndup, strnlen,
 };
 
-use crate::shadowobjs::{SHADOW_STACK, ALIVE_OBJ_LIST, AllocType, FREED_OBJ_LIST, Vaddr};
+use crate::shadowobjs::{ALIVE_OBJ_LIST, AllocType, FREED_OBJ_LIST, GLOBALS, SHADOW_STACK, ShadowObject, Vaddr, lookup_global};
 
 use log::{info, warn};
 
@@ -23,6 +23,11 @@ pub extern "C" fn __resolve_alloca(ptr: *mut c_void, size: usize) -> () {
     );
 
     info!("[STACK] Object allocated with size: {size}, address: 0x{base:x}");
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __resolve_register_global(ptr: *mut c_void, size: usize) {
+    GLOBALS.lock().push(ShadowObject::new(AllocType::Global, ptr as Vaddr, size));
 }
 
 #[unsafe(no_mangle)]
@@ -306,6 +311,17 @@ pub extern "C" fn __resolve_get_bounds_heap(ptr: *mut c_void) -> ShadowObjBounds
     return sobj.into();
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn __resolve_get_bounds_global(ptr: *mut c_void) -> ShadowObjBounds {
+    match lookup_global(ptr as Vaddr) {
+        Some(obj) => ShadowObjBounds {
+            base: obj.base as *mut c_void,
+            limit: obj.past_limit() as *mut c_void
+        },
+        None => ShadowObjBounds::null()
+    }
+}
+
 /**
  * @brief - Generic sobj lookup where we don't know the pointers
  *          allocation type already. Searches stack table ( O(log n) )
@@ -319,6 +335,7 @@ pub extern "C" fn __resolve_get_bounds_heap(ptr: *mut c_void) -> ShadowObjBounds
 pub extern "C" fn __resolve_get_bounds(ptr: *mut c_void) -> ShadowObjBounds {
     let mut sobj = __resolve_get_bounds_stack(ptr);
     if sobj == ShadowObjBounds::null() { sobj = __resolve_get_bounds_heap(ptr)}
+    if sobj == ShadowObjBounds::null() { sobj = __resolve_get_bounds_global(ptr)}
 
     sobj
 }

--- a/resolve-cveassert/libresolve/src/shadowobjs.rs
+++ b/resolve-cveassert/libresolve/src/shadowobjs.rs
@@ -345,7 +345,7 @@ thread_local! {
 pub static GLOBALS: MutexWrap<Vec<ShadowObject>> = MutexWrap::new(Vec::new());
 
 pub fn lookup_global(p: Vaddr) -> Option<ShadowObject> {
-    GLOBALS.lock().iter().find(|obj| obj.contains(p)).copied()
+    GLOBALS.lock().iter().find(|obj| obj.contains(p) || obj.past_limit() == p).copied()
 }
 
 #[cfg(test)]
@@ -387,6 +387,21 @@ mod tests {
 
         let result = table.search_intersection(0x5000);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_lookup_global_in_bounds_one_past_and_miss() {
+        use crate::shadowobjs::{GLOBALS, ShadowObject, lookup_global};
+
+        GLOBALS.lock().clear();
+        GLOBALS.lock().push(ShadowObject::new(AllocType::Global, 0x7000, 4));
+
+        assert!(lookup_global(0x7000).is_some(), "base is in bounds");
+        assert!(lookup_global(0x7003).is_some(), "last valid byte is in bounds");
+        assert!(lookup_global(0x7004).is_some(), "one-past is resolvable");
+        assert!(lookup_global(0x7005).is_none(), "beyond one-past misses");
+
+        GLOBALS.lock().clear();
     }
 
     #[test]

--- a/resolve-cveassert/libresolve/src/shadowobjs.rs
+++ b/resolve-cveassert/libresolve/src/shadowobjs.rs
@@ -3,6 +3,7 @@
 
 use crate::MutexWrap;
 use log::warn;
+use crate::remediate::ShadowObjBounds;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
@@ -18,11 +19,10 @@ pub enum AllocType {
     Unknown,
     Heap,
     Stack,
-    #[allow(dead_code)]
     Global,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ShadowObject {
     /// Allocation type (Heap, Stack, Global, etc..)
     pub alloc_type: AllocType,
@@ -340,6 +340,12 @@ impl ShadowStack {
 
 thread_local! {
     pub static SHADOW_STACK: RefCell<ShadowStack> = RefCell::new(ShadowStack::new());
+}
+
+pub static GLOBALS: MutexWrap<Vec<ShadowObject>> = MutexWrap::new(Vec::new());
+
+pub fn lookup_global(p: Vaddr) -> Option<ShadowObject> {
+    GLOBALS.lock().iter().find(|obj| obj.contains(p)).copied()
 }
 
 #[cfg(test)]

--- a/resolve-cveassert/src/CVEAssert.cpp
+++ b/resolve-cveassert/src/CVEAssert.cpp
@@ -275,7 +275,7 @@ struct LabelCVEPass : public PassInfoMixin<LabelCVEPass> {
   void registerGlobals(Module &M) {
     if (M.getFunction("__resolve_register_globals_ctor"))
       return;
-    
+
     LLVMContext &Ctx = M.getContext();
     const DataLayout &DL = M.getDataLayout();
     auto ptr_ty = PointerType::get(Ctx, 0);
@@ -283,19 +283,19 @@ struct LabelCVEPass : public PassInfoMixin<LabelCVEPass> {
     auto void_ty = Type::getVoidTy(Ctx);
 
     FunctionCallee registerFn = M.getOrInsertFunction(
-      "__resolve_register_global",
-      FunctionType::get(void_ty, {ptr_ty, size_ty}, false)
-    );
+        "__resolve_register_global",
+        FunctionType::get(void_ty, {ptr_ty, size_ty}, false));
 
-    SmallVector<GlobalVariable*, 16> targets;
+    SmallVector<GlobalVariable *, 16> targets;
     for (GlobalVariable &G : M.globals()) {
-      if (G.isDeclaration())                          // external: defining TU registers it
+      if (G.isDeclaration()) // external: defining TU registers it
         continue;
-      if (G.isThreadLocal())                          // TLS: ctor captures one thread's &G
+      if (G.isThreadLocal()) // TLS: ctor captures one thread's &G
         continue;
-      if (G.getType()->getPointerAddressSpace() != 0) // non-default AS: not flat-addressable
+      if (G.getType()->getPointerAddressSpace() !=
+          0) // non-default AS: not flat-addressable
         continue;
-      if (G.getName().starts_with("llvm."))           // used/global_ctors/metadata
+      if (G.getName().starts_with("llvm.")) // used/global_ctors/metadata
         continue;
       if (G.getName().starts_with("__resolve_"))
         continue;
@@ -307,12 +307,9 @@ struct LabelCVEPass : public PassInfoMixin<LabelCVEPass> {
     if (targets.empty())
       return;
 
-    Function *ctor = Function::Create(
-      FunctionType::get(void_ty, {}, false),
-      GlobalValue::InternalLinkage,
-      "__resolve_register_globals_ctor",
-      &M
-    );
+    Function *ctor = Function::Create(FunctionType::get(void_ty, {}, false),
+                                      GlobalValue::InternalLinkage,
+                                      "__resolve_register_globals_ctor", &M);
 
     ctor->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
 
@@ -407,9 +404,8 @@ struct LabelCVEPass : public PassInfoMixin<LabelCVEPass> {
       }
     }
 
-    if (!writePatch &&
-        (instrument_mem_inst.instrumentAlloca ||
-        instrument_mem_inst.instrumentMemAllocator)) {
+    if (!writePatch && (instrument_mem_inst.instrumentAlloca ||
+                        instrument_mem_inst.instrumentMemAllocator)) {
       registerGlobals(M);
       result = PreservedAnalyses::none();
     }

--- a/resolve-cveassert/src/CVEAssert.cpp
+++ b/resolve-cveassert/src/CVEAssert.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -271,6 +272,60 @@ struct LabelCVEPass : public PassInfoMixin<LabelCVEPass> {
     return result;
   }
 
+  void registerGlobals(Module &M) {
+    if (M.getFunction("__resolve_register_globals_ctor"))
+      return;
+    
+    LLVMContext &Ctx = M.getContext();
+    const DataLayout &DL = M.getDataLayout();
+    auto ptr_ty = PointerType::get(Ctx, 0);
+    auto size_ty = Type::getInt64Ty(Ctx);
+    auto void_ty = Type::getVoidTy(Ctx);
+
+    FunctionCallee registerFn = M.getOrInsertFunction(
+      "__resolve_register_global",
+      FunctionType::get(void_ty, {ptr_ty, size_ty}, false)
+    );
+
+    SmallVector<GlobalVariable*, 16> targets;
+    for (GlobalVariable &G : M.globals()) {
+      if (G.isDeclaration())                          // external: defining TU registers it
+        continue;
+      if (G.isThreadLocal())                          // TLS: ctor captures one thread's &G
+        continue;
+      if (G.getType()->getPointerAddressSpace() != 0) // non-default AS: not flat-addressable
+        continue;
+      if (G.getName().starts_with("llvm."))           // used/global_ctors/metadata
+        continue;
+      if (G.getName().starts_with("__resolve_"))
+        continue;
+      if (DL.getTypeAllocSize(G.getValueType()) == 0)
+        continue;
+      targets.push_back(&G);
+    }
+
+    if (targets.empty())
+      return;
+
+    Function *ctor = Function::Create(
+      FunctionType::get(void_ty, {}, false),
+      GlobalValue::InternalLinkage,
+      "__resolve_register_globals_ctor",
+      &M
+    );
+
+    ctor->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
+
+    IRBuilder<> builder(BasicBlock::Create(Ctx, "entry", ctor));
+    for (GlobalVariable *G : targets) {
+      uint64_t size = DL.getTypeAllocSize(G->getValueType());
+      builder.CreateCall(registerFn, {G, ConstantInt::get(size_ty, size)});
+    }
+    builder.CreateRetVoid();
+
+    appendToGlobalCtors(M, ctor, 0);
+  }
+
   PreservedAnalyses
   runInstrumentationPipeline(Module &M, ModuleAnalysisManager &MAM,
                              std::vector<Vulnerability> &vulns,
@@ -352,8 +407,10 @@ struct LabelCVEPass : public PassInfoMixin<LabelCVEPass> {
       }
     }
 
-    if (instrument_mem_inst.instrumentAlloca ||
-        instrument_mem_inst.instrumentMemAllocator) {
+    if (!writePatch &&
+        (instrument_mem_inst.instrumentAlloca ||
+        instrument_mem_inst.instrumentMemAllocator)) {
+      registerGlobals(M);
       result = PreservedAnalyses::none();
     }
     return result;

--- a/resolve-cveassert/tests/lit/global_oob.c
+++ b/resolve-cveassert/tests/lit/global_oob.c
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (c) 2025 Riverside Research.
+ *   LGPL-3; See LICENSE.txt in the repo root for details.
+ */
+
+// Check the registration constructor is emitted and wired into llvm.global_ctors
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_oob.json %clang -S -emit-llvm \
+// RUN: -fpass-plugin=%plugin \
+// RUN: %s -o - | %FileCheck %s
+// CHECK: @llvm.global_ctors ={{.*}}@__resolve_register_globals_ctor
+// CHECK: call void @__resolve_register_global(ptr @global_buffer
+//
+// Test that the remediation is successful (out-of-bounds write)
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_oob.json %clang -O0 -g -fpass-plugin=%plugin \
+// RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
+// RUN: %t.exe 50; EXIT_CODE=$?; \
+// RUN: echo Remediated exit: $EXIT_CODE; test $EXIT_CODE -eq 3
+//
+// Test that the remediation is successful with optimizations
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_oob.json %clang -O3 -fpass-plugin=%plugin \
+// RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
+// RUN: %t.exe 50; EXIT_CODE=$?; \
+// RUN: echo Remediated exit: $EXIT_CODE; test $EXIT_CODE -eq 3
+//
+// Test that the normal behavior is preserved
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_oob.json %clang -O0 -g -fpass-plugin=%plugin \
+// RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
+// RUN: %t.exe 2; EXIT_CODE=$?; \
+// RUN: echo Normal exit: $EXIT_CODE; test $EXIT_CODE -eq 42
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int global_buffer[10] = { 0 };
+
+int use_global(int idx) {
+  global_buffer[idx] = 42;
+  return global_buffer[idx];
+}
+
+int main(int argc, char *argv[]) {
+  int idx = atoi(argv[1]);
+  return use_global(idx);
+}

--- a/resolve-cveassert/tests/lit/global_ro_oob.c
+++ b/resolve-cveassert/tests/lit/global_ro_oob.c
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2025 Riverside Research.
+ *   LGPL-3; See LICENSE.txt in the repo root for details.
+ */
+
+// Check the constant global is registered (constants are intentionally kept)
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_ro_oob.json %clang -S -emit-llvm \
+// RUN: -fpass-plugin=%plugin \
+// RUN: %s -o - | %FileCheck %s
+// CHECK: @llvm.global_ctors ={{.*}}@__resolve_register_globals_ctor
+// CHECK: call void @__resolve_register_global(ptr @secret
+//
+// Test that the remediation is successful (out-of-bounds read)
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_ro_oob.json %clang -O0 -g -fpass-plugin=%plugin \
+// RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
+// RUN: %t.exe 50; EXIT_CODE=$?; \
+// RUN: echo Remediated exit: $EXIT_CODE; test $EXIT_CODE -eq 3
+//
+// Test that the remediation is successful with optimizations
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_ro_oob.json %clang -O3 -fpass-plugin=%plugin \
+// RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
+// RUN: %t.exe 50; EXIT_CODE=$?; \
+// RUN: echo Remediated exit: $EXIT_CODE; test $EXIT_CODE -eq 3
+//
+// Test that the normal behavior is preserved
+// RUN: RESOLVE_LABEL_CVE=vulnerabilities/global_ro_oob.json %clang -O0 -g -fpass-plugin=%plugin \
+// RUN: -L%rlib -lresolve -Wl,-rpath=%rlib %s -o %t.exe
+// RUN: %t.exe 2; EXIT_CODE=$?; \
+// RUN: echo Normal exit: $EXIT_CODE; test $EXIT_CODE -eq 33
+
+#include <stdio.h>
+#include <stdlib.h>
+
+const int secret[4] = { 11, 22, 33, 44 };
+
+int read_global(int idx) {
+  return secret[idx];
+}
+
+int main(int argc, char *argv[]) {
+  int idx = atoi(argv[1]);
+  return read_global(idx);
+}

--- a/resolve-cveassert/tests/lit/vulnerabilities/global_oob.json
+++ b/resolve-cveassert/tests/lit/vulnerabilities/global_oob.json
@@ -1,0 +1,15 @@
+{
+    "vulnerabilities": [
+        {
+            "cve-id": "CVE-resolve-oob-global-1",
+            "cve-description": "",
+            "package-name": "resolve-test",
+            "package-version": "1.4.5",
+            "cwe-id": "787",
+            "cwe-name": "Global OOB write",
+            "affected-function": "use_global",
+            "affected-file": "global_oob.c",
+            "remediation-strategy": "exit"
+        }
+    ]
+}

--- a/resolve-cveassert/tests/lit/vulnerabilities/global_ro_oob.json
+++ b/resolve-cveassert/tests/lit/vulnerabilities/global_ro_oob.json
@@ -1,0 +1,15 @@
+{
+    "vulnerabilities": [
+        {
+            "cve-id": "CVE-resolve-oob-global-2",
+            "cve-description": "",
+            "package-name": "resolve-test",
+            "package-version": "1.4.5",
+            "cwe-id": "125",
+            "cwe-name": "Global OOB read",
+            "affected-function": "read_global",
+            "affected-file": "global_ro_oob.c",
+            "remediation-strategy": "exit"
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds a `GLOBALS: Vec<ShadowObject>` in libresolve (Mutex-gaurded) and some interface functions to push and search through these, as well as a final fallback in `__resolve_get_bounds` which checks the global list before returning `ShadowObjBounds::null()` if nothing is found.

In CVEAssert, before running the pass, it constructs a `ctor` function which iterates over every qualifying global in the module, and instruments calls into libresolve to register them.

This is not the most optimally fast implementation (maybe we can inline checks without hitting libresolve at all, or build an O(1) hash map or something) but it's hopefully enough to handle the currently un-handled global edge-cases. I had codex create two global oob `lit` tests `.bss` write and `.rodata` reads.

_**Note:**_ This is based on `dev/libresolve-stack`, so currently has extra commits/files compared to main.