### PR TITLE
[PR]  Tag trivial GEPs

### DIFF
--- a/resolve-cveassert/src/arith_san.cpp
+++ b/resolve-cveassert/src/arith_san.cpp
@@ -136,11 +136,11 @@ void sanitizeDivideByZero(Function *F,
 
     BasicBlock *checkMapEntryBB = binary_inst->getParent();
     BasicBlock *joinResultBB = checkMapEntryBB->splitBasicBlock(binary_inst);
-    BasicBlock *checkZeroBB = BasicBlock::Create(Ctx, "check_zero", F);
+    BasicBlock *checkZeroBB = BasicBlock::Create(Ctx, "check.zero", F);
     BasicBlock *preserveDivBB =
-        BasicBlock::Create(Ctx, "preserve_division", F, joinResultBB);
+        BasicBlock::Create(Ctx, "safe.div", F, joinResultBB);
     BasicBlock *remedDivBB =
-        BasicBlock::Create(Ctx, "remediate_division", F, joinResultBB);
+        BasicBlock::Create(Ctx, "sanitize.div", F, joinResultBB);
 
     checkMapEntryBB->getTerminator()->eraseFromParent();
     builder.SetInsertPoint(checkMapEntryBB);
@@ -397,9 +397,9 @@ void sanitizeIntOverflow(Function *F,
 
     BasicBlock *checkMapEntryBB = binary_inst->getParent();
     BasicBlock *joinResultBB = checkMapEntryBB->splitBasicBlock(binary_inst);
-    BasicBlock *checkOverflowBB = BasicBlock::Create(Ctx, "check_overflow", F);
+    BasicBlock *checkOverflowBB = BasicBlock::Create(Ctx, "check.overflow", F);
     BasicBlock *remedOverflowBB =
-        BasicBlock::Create(Ctx, "remediate_overflow", F, joinResultBB);
+        BasicBlock::Create(Ctx, "sanitize.overflow", F, joinResultBB);
 
     checkMapEntryBB->getTerminator()->eraseFromParent();
     builder.SetInsertPoint(checkMapEntryBB);
@@ -471,11 +471,11 @@ void sanitizeBitShift(Function *F,
 
     BasicBlock *checkMapEntryBB = binary_inst->getParent();
     BasicBlock *joinResultBB = checkMapEntryBB->splitBasicBlock(binary_inst);
-    BasicBlock *checkShiftBB = BasicBlock::Create(Ctx, "check_zero", F);
+    BasicBlock *checkShiftBB = BasicBlock::Create(Ctx, "check.zero", F);
     BasicBlock *preserveShiftBB =
-        BasicBlock::Create(Ctx, "preserve_shift", F, joinResultBB);
+        BasicBlock::Create(Ctx, "safe.shift", F, joinResultBB);
     BasicBlock *remedShiftBB =
-        BasicBlock::Create(Ctx, "remediate_shift", F, joinResultBB);
+        BasicBlock::Create(Ctx, "sanitize.shift", F, joinResultBB);
 
     checkMapEntryBB->getTerminator()->eraseFromParent();
     builder.SetInsertPoint(checkMapEntryBB);

--- a/resolve-cveassert/src/bounds_check.cpp
+++ b/resolve-cveassert/src/bounds_check.cpp
@@ -190,7 +190,7 @@ static Function *getOrCreateBoundsCheckLoadSanitizer(
   BasicBlock *NormalLoadBB =
       BasicBlock::Create(Ctx, "safe.load", resolveLoadFn);
   BasicBlock *SanitizeLoadBB =
-      BasicBlock::Create(Ctx, "trap.load", resolveLoadFn);
+      BasicBlock::Create(Ctx, "sanitize.load", resolveLoadFn);
 
   builder.SetInsertPoint(EntryBB);
   Value *basePtr = resolveLoadFn->getArg(0);
@@ -254,7 +254,7 @@ static Function *getOrCreateBoundsCheckStoreSanitizer(
   BasicBlock *NormalStoreBB =
       BasicBlock::Create(Ctx, "safe.store", resolveStoreFn);
   BasicBlock *SanitizeStoreBB =
-      BasicBlock::Create(Ctx, "trap.store", resolveStoreFn);
+      BasicBlock::Create(Ctx, "sanitize.store", resolveStoreFn);
 
   builder.SetInsertPoint(EntryBB);
   Value *basePtr = resolveStoreFn->getArg(0);
@@ -317,7 +317,7 @@ static Function *getOrCreateBoundsCheckMemcpySanitizer(
   BasicBlock *NormalBB =
       BasicBlock::Create(Ctx, "safe.memcpy", resolveMemmoveFn);
   BasicBlock *SanitizeMemcpyBB =
-      BasicBlock::Create(Ctx, "trap.memcpy", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "sanitize.memcpy", resolveMemmoveFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract dst, src, size arguments from function
@@ -387,7 +387,7 @@ static Function *getOrCreateBoundsCheckMemmoveSanitizer(
   BasicBlock *NormalBB =
       BasicBlock::Create(Ctx, "safe.memmove", resolveMemmoveFn);
   BasicBlock *SanitizeMemmoveBB =
-      BasicBlock::Create(Ctx, "trap.memmove", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "sanitize.memmove", resolveMemmoveFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract dst, src, size arguments from function
@@ -458,7 +458,7 @@ static Function *getOrCreateBoundsCheckMemsetSanitizer(
   BasicBlock *NormalBB =
       BasicBlock::Create(Ctx, "safe.memset", resolveMemsetFn);
   BasicBlock *SanitizeMemsetBB =
-      BasicBlock::Create(Ctx, "trap.memset", resolveMemsetFn);
+      BasicBlock::Create(Ctx, "sanitize.memset", resolveMemsetFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract arguments for memset

--- a/resolve-cveassert/src/bounds_check.cpp
+++ b/resolve-cveassert/src/bounds_check.cpp
@@ -123,11 +123,11 @@ static Function *getOrCreateAccessOk(Module *M, BoundsClass cls) {
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveAccessOkFn);
   BasicBlock *CheckAccessBB =
-      BasicBlock::Create(Ctx, "check_access", resolveAccessOkFn);
+      BasicBlock::Create(Ctx, "check.access", resolveAccessOkFn);
   BasicBlock *TrueBB =
-      BasicBlock::Create(Ctx, "return_true", resolveAccessOkFn);
+      BasicBlock::Create(Ctx, "safe.access", resolveAccessOkFn);
   BasicBlock *FalseBB =
-      BasicBlock::Create(Ctx, "return_false", resolveAccessOkFn);
+      BasicBlock::Create(Ctx, "unsafe.access", resolveAccessOkFn);
 
   builder.SetInsertPoint(EntryBB);
 
@@ -186,11 +186,11 @@ static Function *getOrCreateBoundsCheckLoadSanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveLoadFn);
   BasicBlock *CheckAccessBB =
-      BasicBlock::Create(Ctx, "check_access", resolveLoadFn);
+      BasicBlock::Create(Ctx, "check.access", resolveLoadFn);
   BasicBlock *NormalLoadBB =
-      BasicBlock::Create(Ctx, "normal_load", resolveLoadFn);
+      BasicBlock::Create(Ctx, "safe.load", resolveLoadFn);
   BasicBlock *SanitizeLoadBB =
-      BasicBlock::Create(Ctx, "sanitize_load", resolveLoadFn);
+      BasicBlock::Create(Ctx, "trap.load", resolveLoadFn);
 
   builder.SetInsertPoint(EntryBB);
   Value *basePtr = resolveLoadFn->getArg(0);
@@ -250,11 +250,11 @@ static Function *getOrCreateBoundsCheckStoreSanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveStoreFn);
   BasicBlock *CheckAccessBB =
-      BasicBlock::Create(Ctx, "check_access", resolveStoreFn);
+      BasicBlock::Create(Ctx, "check.access", resolveStoreFn);
   BasicBlock *NormalStoreBB =
-      BasicBlock::Create(Ctx, "normal_store", resolveStoreFn);
+      BasicBlock::Create(Ctx, "safe.store", resolveStoreFn);
   BasicBlock *SanitizeStoreBB =
-      BasicBlock::Create(Ctx, "sanitize_store", resolveStoreFn);
+      BasicBlock::Create(Ctx, "trap.store", resolveStoreFn);
 
   builder.SetInsertPoint(EntryBB);
   Value *basePtr = resolveStoreFn->getArg(0);
@@ -313,11 +313,11 @@ static Function *getOrCreateBoundsCheckMemcpySanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveMemmoveFn);
   BasicBlock *CheckAccessBB =
-      BasicBlock::Create(Ctx, "check_access", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "check.access", resolveMemmoveFn);
   BasicBlock *NormalBB =
-      BasicBlock::Create(Ctx, "safe_memcpy", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "safe.memcpy", resolveMemmoveFn);
   BasicBlock *SanitizeMemcpyBB =
-      BasicBlock::Create(Ctx, "sanitize_memcpy", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "trap.memcpy", resolveMemmoveFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract dst, src, size arguments from function
@@ -383,11 +383,11 @@ static Function *getOrCreateBoundsCheckMemmoveSanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveMemmoveFn);
   BasicBlock *CheckAccessBB =
-      BasicBlock::Create(Ctx, "check_access", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "check.access", resolveMemmoveFn);
   BasicBlock *NormalBB =
-      BasicBlock::Create(Ctx, "safe_memmove", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "safe.memmove", resolveMemmoveFn);
   BasicBlock *SanitizeMemmoveBB =
-      BasicBlock::Create(Ctx, "sanitize_memmove", resolveMemmoveFn);
+      BasicBlock::Create(Ctx, "trap.memmove", resolveMemmoveFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract dst, src, size arguments from function
@@ -454,11 +454,11 @@ static Function *getOrCreateBoundsCheckMemsetSanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveMemsetFn);
   BasicBlock *CheckAccessBB =
-      BasicBlock::Create(Ctx, "check_access", resolveMemsetFn);
+      BasicBlock::Create(Ctx, "check.access", resolveMemsetFn);
   BasicBlock *NormalBB =
-      BasicBlock::Create(Ctx, "safe_memset", resolveMemsetFn);
+      BasicBlock::Create(Ctx, "safe.memset", resolveMemsetFn);
   BasicBlock *SanitizeMemsetBB =
-      BasicBlock::Create(Ctx, "sanitize_memset", resolveMemsetFn);
+      BasicBlock::Create(Ctx, "trap.memset", resolveMemsetFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract arguments for memset
@@ -523,13 +523,11 @@ static Function *getOrCreateResolveGep(Function *F, BoundsClass cls) {
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveGepFn);
   BasicBlock *GetBaseAndLimitBB =
-      BasicBlock::Create(Ctx, "get_base_and_limit", resolveGepFn);
+      BasicBlock::Create(Ctx, "get.bounds", resolveGepFn);
   BasicBlock *CheckComputedPtrBB =
-      BasicBlock::Create(Ctx, "check_access", resolveGepFn);
-  BasicBlock *NormalBB =
-      BasicBlock::Create(Ctx, "return_normal_ptr", resolveGepFn);
-  BasicBlock *OnePastBB =
-      BasicBlock::Create(Ctx, "return_tainted_ptr", resolveGepFn);
+      BasicBlock::Create(Ctx, "check.access", resolveGepFn);
+  BasicBlock *NormalBB = BasicBlock::Create(Ctx, "safe.ptr", resolveGepFn);
+  BasicBlock *OnePastBB = BasicBlock::Create(Ctx, "tainted.ptr", resolveGepFn);
 
   builder.SetInsertPoint(EntryBB);
   // Extract the base and derived pointer

--- a/resolve-cveassert/src/bounds_check.cpp
+++ b/resolve-cveassert/src/bounds_check.cpp
@@ -134,8 +134,8 @@ static Function *getOrCreateAccessOk(Module *M, BoundsClass cls) {
   Value *basePtr = resolveAccessOkFn->getArg(0);
   Value *accessSize = resolveAccessOkFn->getArg(1);
 
-  Value *baseAndLimit =
-      builder.CreateCall(getOrCreateResolveGetBounds(M, cls), {basePtr});
+  Value *baseAndLimit = builder.CreateCall(getOrCreateResolveGetBounds(M, cls),
+                                           {basePtr}, "resolve.bounds");
   Value *limitValue = builder.CreateExtractValue(baseAndLimit, 1);
   Value *limitInt = builder.CreatePtrToInt(limitValue, size_ty);
   Value *baseInt = builder.CreatePtrToInt(basePtr, size_ty);

--- a/resolve-cveassert/src/instrument.cpp
+++ b/resolve-cveassert/src/instrument.cpp
@@ -134,19 +134,30 @@ void instrumentAlloca(Function *F) {
     Function *F = transformedAlloca->getFunction();
     BasicBlock &entryBB = F->getEntryBlock();
     Instruction *insertPt = &*entryBB.getFirstInsertionPt();
+    GetElementPtrInst *Gep;
     builder.SetInsertPoint(insertPt);
     AllocaInst *shadowSlot =
         builder.CreateAlloca(shadowTy, nullptr, "shadow.slot");
     Value *initialPtrField = builder.CreateStructGEP(shadowTy, shadowSlot, 0);
     builder.CreateStore(ConstantPointerNull::get(ptr_ty), initialPtrField);
     Value *initialSizeField = builder.CreateStructGEP(shadowTy, shadowSlot, 1);
+    Gep = cast<GetElementPtrInst>(initialPtrField);
+    Gep->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
     builder.CreateStore(ConstantInt::get(size_ty, 0), initialSizeField);
     builder.SetInsertPoint(transformedAlloca->getNextNonDebugInstruction());
+
     Value *runtimePtrField = builder.CreateStructGEP(shadowTy, shadowSlot, 0);
+    Gep = cast<GetElementPtrInst>(runtimePtrField);
+    Gep->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
+
     StoreInst *storeStackAddr =
         builder.CreateStore(transformedAlloca, runtimePtrField);
     storeStackAddr->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
+
     Value *runtimeSizeField = builder.CreateStructGEP(shadowTy, shadowSlot, 1);
+    Gep = cast<GetElementPtrInst>(runtimeSizeField);
+    Gep->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));
+
     StoreInst *storeStackSize =
         builder.CreateStore(totalSize, runtimeSizeField);
     storeStackSize->setMetadata("cve.noinstrument", MDNode::get(Ctx, {}));

--- a/resolve-cveassert/src/nonheap_free.cpp
+++ b/resolve-cveassert/src/nonheap_free.cpp
@@ -81,11 +81,11 @@ Function *getOrCreateFreeOfNonHeapSanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", cveFreeNonHeapFn);
   BasicBlock *CheckOnHeapBB =
-      BasicBlock::Create(Ctx, "check_heap", cveFreeNonHeapFn);
+      BasicBlock::Create(Ctx, "check.heap", cveFreeNonHeapFn);
   BasicBlock *SanitizeNonHeapBB =
-      BasicBlock::Create(Ctx, "sanitize_nonheap", cveFreeNonHeapFn);
+      BasicBlock::Create(Ctx, "sanitize.nonheap", cveFreeNonHeapFn);
   BasicBlock *FreeHeapBB =
-      BasicBlock::Create(Ctx, "free_heap", cveFreeNonHeapFn);
+      BasicBlock::Create(Ctx, "free.heap", cveFreeNonHeapFn);
 
   // Set insertion point to entry block
   builder.SetInsertPoint(EntryBB);

--- a/resolve-cveassert/src/null_ptr.cpp
+++ b/resolve-cveassert/src/null_ptr.cpp
@@ -41,11 +41,11 @@ getOrCreateNullPtrLoadSanitizer(Function *F, Type *ty,
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveNullPtrLdFn);
   BasicBlock *CheckIfNullBB =
-      BasicBlock::Create(Ctx, "check_if_null", resolveNullPtrLdFn);
+      BasicBlock::Create(Ctx, "check.null", resolveNullPtrLdFn);
   BasicBlock *SanitizeNullPtrBB =
-      BasicBlock::Create(Ctx, "sanitize_null_ptr", resolveNullPtrLdFn);
+      BasicBlock::Create(Ctx, "sanitize.load", resolveNullPtrLdFn);
   BasicBlock *NormalLoadBB =
-      BasicBlock::Create(Ctx, "safe_load", resolveNullPtrLdFn);
+      BasicBlock::Create(Ctx, "safe.load", resolveNullPtrLdFn);
 
   builder.SetInsertPoint(EntryBB);
   Argument *inputPtr = resolveNullPtrLdFn->getArg(0);
@@ -110,11 +110,11 @@ static Function *getOrCreateNullPtrStoreSanitizer(
 
   BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", resolveNullPtrStFn);
   BasicBlock *CheckIfNullBB =
-      BasicBlock::Create(Ctx, "check_if_null", resolveNullPtrStFn);
+      BasicBlock::Create(Ctx, "check.null", resolveNullPtrStFn);
   BasicBlock *SanitizeNullPtrBB =
-      BasicBlock::Create(Ctx, "sanitize_null_ptr", resolveNullPtrStFn);
+      BasicBlock::Create(Ctx, "sanitize.store", resolveNullPtrStFn);
   BasicBlock *NormalStoreBB =
-      BasicBlock::Create(Ctx, "safe_store", resolveNullPtrStFn);
+      BasicBlock::Create(Ctx, "safe.store", resolveNullPtrStFn);
 
   // Set insertion point to entry block
   builder.SetInsertPoint(EntryBB);


### PR DESCRIPTION
This PR contains changes that tag GEP instructions with cve.noinstrument metadata used for in shadow slot initialization. This declutters the IR by not emitting calls to __cve_gep after every shadow slot field calculation. 